### PR TITLE
added bugfix for importing bibtex

### DIFF
--- a/R/parse_functions.R
+++ b/R/parse_functions.R
@@ -278,6 +278,12 @@ if(any(unlist(lapply(x_split, nrow))==1)){
 #' @rdname parse_
 parse_bibtex <- function(x){
 
+  ### Remove lines that start with a percentage symbol (comments)
+  x <- grep("^\\s*%.*",
+            x,
+            invert = TRUE,
+            value=TRUE)
+
   # which lines start with @article?
   group_vec <- rep(0, length(x))
   row_id <- which(regexpr("^@", x) == 1)


### PR DESCRIPTION
This sanitizes all lines that start with a percentage charactere from .bib files before starting the import. Without this, those (valid .bibtex) files throw an error:

`Error in if (any(names(entry_list) == "author")) { : 
  missing value where TRUE/FALSE needed`